### PR TITLE
[Feat] #3 - 교보문고 해시태그 크롤링 구현

### DIFF
--- a/crawling.py
+++ b/crawling.py
@@ -1,0 +1,36 @@
+from selenium import webdriver
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.service import Service
+import time
+
+# 도서 검색 결과 페이지에서 해시태그 정보 가져오기
+def get_hashtags(isbn):
+    search_url = f"https://search.kyobobook.co.kr/search?keyword={isbn}"
+    
+    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()))
+    driver.get(search_url)
+    
+    time.sleep(3)  # 페이지가 완전히 로드될 때까지 잠시 대기
+
+    # 해시태그 리스트 추출
+    try:
+        hashtags_elements = driver.find_elements(By.CSS_SELECTOR, 'a.tag')
+        hashtags = [tag.text for tag in hashtags_elements]
+        hashtags = [tag.replace("#", "") for tag in hashtags]   # 해시태그 기호 제거
+        category = hashtags[0]  # 첫 번째 해시태그는 카테고리로 사용
+        hashtags = list(set(hashtags[1:]))[1:]  # 중복 제거 후 두 번째 해시태그부터 사용
+
+        return category, hashtags
+    
+    except Exception as e:
+        print(f"해시태그를 찾는 중 오류 발생: {e}")
+        return None, None
+    
+    driver.quit()
+
+# 예시 실행
+# isbn = "9788925538297"
+isbn = '9788954699372'
+category, hashtags = get_hashtags(isbn)
+print(f"{isbn}\n카테고리: {category}, 해시태그 목록: {hashtags}")


### PR DESCRIPTION
## 🌳 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 해시태그 크롤링 함수 구현을 완료했습니다.

## 💭 PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- 도서의 ISBN을 매개변수로 제공하면 교보문고 도서 검색 페이지에 접근해 해시태그를 받아옵니다.
- 카테고리와 일반 해시태그를 분류하여 반환합니다.

## 🌈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #3 
